### PR TITLE
Fix metadata related to supported platforms.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
     - name: Debian
       versions:
         - jessie
-    - name: Darwin
+    - name: MacOSX
       versions:
         - all
 


### PR DESCRIPTION
FYI: https://galaxy.ansible.com/api/v1/platforms/

- Now, MacOS is used instead of Darwin.